### PR TITLE
Added BuildKit flags fix to INSTALL.md

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -6,7 +6,7 @@ and Docker Compose (version 1.6.0 or greater) already installed.
 1. Download the `szurubooru` source:
 
     ```console
-    user@host:~$ git clone https://github.com/skybldev/szurubooru.git szuru
+    user@host:~$ git clone https://github.com/rr-/szurubooru.git szuru
     user@host:~$ cd szuru
     ```
 2. Configure the application:
@@ -34,43 +34,79 @@ and Docker Compose (version 1.6.0 or greater) already installed.
     Read the comments to guide you. Note that `.env` should be in the root
     directory of this repository.
 
-### Building and Running the Application
+4. Pull the containers:
 
-Unlike the original szurubooru, this will need to be built locally:
-```console
-user@host:szuru$ docker-compose build
-```
+    This pulls the latest containers from docker.io:
+    ```console
+    user@host:szuru$ docker-compose pull
+    ```
+    
+    If you have modified the application's source and would like to manually
+    build it, follow the instructions in [**Building**](#Building) instead,
+    then read here once you're done.
 
-For first run, it is recommended to start the database separately:
-```console
-user@host:szuru$ docker-compose up -d sql
-```
+5. Run it!
 
-To start all containers:
-```console
-user@host:szuru$ docker-compose up -d
-```
+    For first run, it is recommended to start the database separately:
+    ```console
+    user@host:szuru$ docker-compose up -d sql
+    ```
 
-To view/monitor the application logs:
-```console
-user@host:szuru$ docker-compose logs -f
-# (CTRL+C to exit)
-```
+    To start all containers:
+    ```console
+    user@host:szuru$ docker-compose up -d
+    ```
 
-To stop all containers:
-```console
-user@host:szuru$ docker-compose down
-```
+    To view/monitor the application logs:
+    ```console
+    user@host:szuru$ docker-compose logs -f
+    # (CTRL+C to exit)
+    ```
 
-NOTE: For Debian users, if `docker-compose build` spits out:
-```
-ERROR: Service 'server' failed to build: failed to parse platform : "" is an invalid component of "": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument
-```
-...you will need to export Docker BuildKit flags:
-```console
-user@host:szuru$export DOCKER_BUILDKIT=1; export COMPOSE_DOCKER_CLI_BUILD=1
-```
-...then run again.
+### Building
+
+1. Edit `docker-compose.yml` to tell Docker to build instead of pull containers:
+
+    ```diff yaml
+    ...
+    server:
+    - image: szurubooru/server:latest
+    + build: server
+    ...
+    client:
+    - image: szurubooru/client:latest
+    + build: client
+    ...
+    ```
+
+    You can choose to build either one from source.
+
+2. Build the containers:
+
+    ```console
+    user@host:szuru$ docker-compose build
+    ```
+
+    That will attempt to build both containers, but you can specify `client`
+    or `server` to make it build only one.
+
+    If `docker-compose build` spits out: 
+
+    ```
+    ERROR: Service 'server' failed to build: failed to parse platform : "" is an invalid component of "": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument
+    ```
+
+    ...you will need to export Docker BuildKit flags:
+
+    ```console
+    user@host:szuru$ export DOCKER_BUILDKIT=1; export COMPOSE_DOCKER_CLI_BUILD=1
+    ```
+
+    ...and run `docker-compose build` again.
+
+*Note: If your changes are not taking effect in your builds, consider building
+with `--no-cache`.*
+
 
 ### Additional Features
 


### PR DESCRIPTION
Added this because recently, there have been more problems with `docker-compose build` where it errors:

    ERROR: Service 'server' failed to build: failed to parse platform : "" is an invalid component of "": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument

Recent Docker versions have switched to using `buildx` (BuildKit) to build containers, but that needs to be enabled, either in `daemon.json` or through an environment variable. But since we are using Docker Compose, it doesn't pass it to Docker; so the environment variable needs to be set. At least that's what I've heard and figured out 😅 My explanation might be very wrong - but it works :)